### PR TITLE
refactor: add v1.24.3 constraint, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,27 @@ This add-on provides integration for Ibexa Cloud and adds the `ddev ibexa_cloud`
 
 1. Configure your Ibexa project for DDEV if you haven't already, see [DDEV Ibexa Quickstart](https://ddev.readthedocs.io/en/stable/users/quickstart/#ibexa-dxp)
 2. `ddev add-on get ddev/ddev-ibexa-cloud`
-3. Configure your `IBEXA_CLI_TOKEN` globally, `ddev config global --web-environment-add=IBEXA_CLI_TOKEN=nf4amudfn23biyourtoken`
-4. Configure your `IBEXA_PROJECT`, `IBEXA_ENVIRONMENT`, and `IBEXA_APP` environment variables, for example `ddev config --web-environment-add=IBEXA_PROJECT=nf4amudfn23biyourproject,IBEXA_ENVIRONMENT=main,IBEXA_APP=app`
-5. `ddev restart`
-6. `ddev pull ibexa-cloud`
+3. Configure your `IBEXA_CLI_TOKEN` globally:
+
+   ```bash
+   ddev config global --web-environment-add=IBEXA_CLI_TOKEN=nf4amudfn23biyourtoken
+   ```
+
+4. (Optional) To use multiple API tokens for different projects, add them to your per-project configuration using the [.ddev/config.local.yaml](https://ddev.readthedocs.io/en/stable/users/configuration/config/#environmental-overrides) file instead. This file is gitignored by default.
+
+   ```yaml
+   web_environment:
+    - IBEXA_CLI_TOKEN=nf4amudfn23biyourtoken
+   ```
+
+5. Configure your `IBEXA_PROJECT`, `IBEXA_ENVIRONMENT`, and `IBEXA_APP` environment variables, for example:
+
+   ```bash
+   ddev config --web-environment-add=IBEXA_PROJECT=nf4amudfn23biyourproject,IBEXA_ENVIRONMENT=main,IBEXA_APP=app
+   ```
+
+6. `ddev restart`
+7. `ddev pull ibexa-cloud`
 
 After installation, make sure to commit the `.ddev` directory to version control.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,32 @@
-[![tests](https://github.com/ddev/ddev-ibexa-cloud/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-ibexa-cloud/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)
+[![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
+[![tests](https://github.com/ddev/ddev-ibexa-cloud/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-ibexa-cloud/actions/workflows/tests.yml?query=branch%3Amain)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-ibexa-cloud)](https://github.com/ddev/ddev-ibexa-cloud/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-ibexa-cloud)](https://github.com/ddev/ddev-ibexa-cloud/releases/latest)
+
+# DDEV Ibexa Cloud
+
+## Overview
 
 The [Ibexa Cloud](https://www.ibexa.co/products/ibexa-cloud) has its own CLI, instead of using the `platform` CLI.
 
-This add-on provides integration for Ibexa Cloud and adds the `ddev ibexa_cloud` custom command.
+This add-on provides integration for Ibexa Cloud and adds the `ddev ibexa_cloud` custom command into your [DDEV](https://ddev.com/) project.
+
+## Installation
 
 1. Configure your Ibexa project for DDEV if you haven't already, see [DDEV Ibexa Quickstart](https://ddev.readthedocs.io/en/stable/users/quickstart/#ibexa-dxp)
-2. `ddev get ddev/ddev-ibexa-cloud` (# or in DDEV v1.23.5+ `ddev add-on get ddev/ddev-ibexa-cloud`)
+2. `ddev add-on get ddev/ddev-ibexa-cloud`
 3. Configure your IBEXA_CLI_TOKEN globally, `ddev config global --web-environment-add=IBEXA_CLI_TOKEN=nf4amudfn23biyourtoken`
 4. Configure your IBEXA_PROJECT, IBEXA_ENVIRONMENT, and IBEXA_APP environment variables, for example `ddev config --web-environment-add=IBEXA_PROJECT=nf4amudfn23biyourproject,IBEXA_ENVIRONMENT=main,IBEXA_APP=app`
 5. `ddev restart`
 6. `ddev pull ibexa-cloud`
+
+After installation, make sure to commit the `.ddev` directory to version control.
 
 ## Running Automated Tests Locally
 
 * `IBEXA_CLI_TOKEN`, `IBEXA_PROJECT` and `IBEXA_ENVIRONMENT` should exist in the environment
 * `brew tap kaos/shell && brew install bats-assert bats-file`
 
+## Credits
 
 **Contributed and maintained by [@rfay](https://github.com/rfay)**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,19 @@ This add-on provides integration for Ibexa Cloud and adds the `ddev ibexa_cloud`
 
 1. Configure your Ibexa project for DDEV if you haven't already, see [DDEV Ibexa Quickstart](https://ddev.readthedocs.io/en/stable/users/quickstart/#ibexa-dxp)
 2. `ddev add-on get ddev/ddev-ibexa-cloud`
-3. Configure your IBEXA_CLI_TOKEN globally, `ddev config global --web-environment-add=IBEXA_CLI_TOKEN=nf4amudfn23biyourtoken`
-4. Configure your IBEXA_PROJECT, IBEXA_ENVIRONMENT, and IBEXA_APP environment variables, for example `ddev config --web-environment-add=IBEXA_PROJECT=nf4amudfn23biyourproject,IBEXA_ENVIRONMENT=main,IBEXA_APP=app`
+3. Configure your `IBEXA_CLI_TOKEN` globally, `ddev config global --web-environment-add=IBEXA_CLI_TOKEN=nf4amudfn23biyourtoken`
+4. Configure your `IBEXA_PROJECT`, `IBEXA_ENVIRONMENT`, and `IBEXA_APP` environment variables, for example `ddev config --web-environment-add=IBEXA_PROJECT=nf4amudfn23biyourproject,IBEXA_ENVIRONMENT=main,IBEXA_APP=app`
 5. `ddev restart`
 6. `ddev pull ibexa-cloud`
 
 After installation, make sure to commit the `.ddev` directory to version control.
+
+## Usage
+
+| Command | Description |
+| ------- | ----------- |
+| `ddev ibexa_cloud` | Run `ibexa_cloud` CLI inside the web container |
+| `ddev pull ibexa-cloud` | Pull the configured environment |
 
 ## Running Automated Tests Locally
 

--- a/install.yaml
+++ b/install.yaml
@@ -1,6 +1,4 @@
-
 name: ibexa-cloud
-pre_install_actions:
 
 project_files:
   - commands/web/ibexa_cloud
@@ -8,11 +6,4 @@ project_files:
   - providers/ibexa-cloud.yaml
   - web-build/Dockerfile.ibexa-cloud
 
-global_files:
-dependencies:
-
-post_install_actions:
-removal_actions:
-
-yaml_read_files:
-
+ddev_version_constraint: '>= v1.24.3'


### PR DESCRIPTION
## The Issue

Upstream `ddev-addon-template` has some changes.

## How This PR Solves The Issue

- Adds badges to README.md
- Adds version constraint v1.24.3

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-ibexa-cloud/tarball/20250418_stasadev_bats
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
