### PR TITLE
Installer now installs into /usr/bin and does not need copy

### DIFF
--- a/web-build/Dockerfile.ibexa-cloud
+++ b/web-build/Dockerfile.ibexa-cloud
@@ -1,4 +1,3 @@
 #ddev-generated
 ENV PLATFORMSH_CLI_HOME=/usr/local/bin
-RUN curl -sfS https://cli.ibexa.cloud/installer | php
-RUN cp /root/.ibexa-cli/bin/ibexa_cloud /usr/local/bin
+RUN curl -sfS https://cli.ibexa.cloud/installer | sh

--- a/web-build/Dockerfile.ibexa-cloud
+++ b/web-build/Dockerfile.ibexa-cloud
@@ -1,3 +1,2 @@
 #ddev-generated
-ENV PLATFORMSH_CLI_HOME=/usr/local/bin
 RUN curl -sfS https://cli.ibexa.cloud/installer | sh

--- a/web-build/Dockerfile.ibexa-cloud
+++ b/web-build/Dockerfile.ibexa-cloud
@@ -1,2 +1,3 @@
 #ddev-generated
 RUN curl -sfS https://cli.ibexa.cloud/installer | sh
+RUN chmod ugo+rx /root


### PR DESCRIPTION
## The Issue

Tests have been failing:

https://github.com/ddev/ddev-ibexa-cloud/actions/runs/29681043078

## How This PR Solves The Issue

The installer was changed to use sh to install, and directly installs to /usr/bin

